### PR TITLE
Fix wrong-type-argument error in `show-paren-match-face'

### DIFF
--- a/material-theme.el
+++ b/material-theme.el
@@ -223,7 +223,7 @@
    `(whitespace-hspace ((,class (:background nil :foreground ,selection))))
 
    ;; Parenthesis matching (built-in)
-   `(show-paren-match-face ((,class (:background aqua :foreground "black"))))
+   `(show-paren-match-face ((,class (:background ,aqua :foreground "black"))))
    `(show-paren-mismatch-face ((,class (:background "red1" :foreground "white"))))
 
    ;; Smartparens paren matching


### PR DESCRIPTION
This fixes a minor error occurring in `show-paren-match-face`.  Should be a fairly self-explanatory patch!