### PR TITLE
Improved Readability for light variant

### DIFF
--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -558,11 +558,11 @@
    `(cfw:face-holiday ((,class (:background ,current-line :foreground ,green :weight bold))))
 
    ;; Jabber
-   `(jabber-chat-prompt-local ((,class (:foreground ,yellow))))
-   `(jabber-chat-prompt-foreign ((,class (:foreground ,orange))))
-   `(jabber-chat-prompt-system ((,class (:foreground ,yellow :weight bold))))
-   `(jabber-chat-text-local ((,class (:foreground ,yellow))))
-   `(jabber-chat-text-foreign ((,class (:foreground ,orange))))
+   `(jabber-chat-prompt-local ((,class (:foreground ,subtle))))
+   `(jabber-chat-prompt-foreign ((,class (:foreground ,blue))))
+   `(jabber-chat-prompt-system ((,class (:foreground ,orange :weight bold))))
+   `(jabber-chat-text-local ((,class (:foreground ,subtle))))
+   `(jabber-chat-text-foreign ((,class (:foreground ,foreground))))
    `(jabber-chat-text-error ((,class (:foreground ,red))))
 
    `(jabber-roster-user-online ((,class (:foreground ,green))))

--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -389,6 +389,7 @@
    ;; Helm
    `(helm-header ((,class (:foreground ,foreground :background ,background))))
    `(helm-selection ((,class (:background ,current-line :foreground ,blue))))
+   `(helm-match ((,class (:foreground ,comment))))
    `(helm-ff-file ((,class (:foreground ,foreground ))))
    `(helm-ff-directory ((,class (:foreground ,blue ))))
    `(helm-ff-executable ((,class (:foreground ,green ))))

--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -110,7 +110,11 @@
 
    ;; Flycheck
    `(flycheck-error ((,class (:underline (:style wave :color ,red)))))
+   `(flycheck-info ((,class (:underline (:style wave :color ,blue)))))
    `(flycheck-warning ((,class (:underline (:style wave :color ,orange)))))
+   `(flycheck-fringe-error ((,class (:foreground ,red :background ,current-line))))
+   `(flycheck-fringe-info ((,class (:foreground ,blue :background ,current-line))))
+   `(flycheck-fringe-warning ((,class (:foreground ,yellow :background ,current-line))))
 
    ;; highlight indentation
    `(highlight-indentation-face ((,class (:background, current-line))))

--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -645,11 +645,12 @@
    `(font-latex-warning-face              ((t (:inherit font-lock-warning-face))))
 
    ;; mu4e
-   `(mu4e-header-highlight-face ((,class (:underline nil :inherit region))))
+   `(mu4e-header-face ((,class (:foreground ,subtle :inherit nil))))
+   `(mu4e-header-highlight-face ((,class (:foreground ,foreground :background ,current-line :underline nil :inherit region))))
    `(mu4e-header-marks-face ((,class (:underline nil :foreground ,yellow))))
    `(mu4e-flagged-face ((,class (:foreground ,orange :inherit nil))))
    `(mu4e-replied-face ((,class (:foreground ,blue :inherit nil))))
-   `(mu4e-unread-face ((,class (:foreground ,yellow :inherit nil))))
+   `(mu4e-unread-face ((,class (:foreground nil :inherit nil))))
    `(mu4e-cited-1-face ((,class (:inherit outline-1 :slant normal))))
    `(mu4e-cited-2-face ((,class (:inherit outline-2 :slant normal))))
    `(mu4e-cited-3-face ((,class (:inherit outline-3 :slant normal))))

--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -402,8 +402,8 @@
 
    ;; guide-key
    `(guide-key/key-face ((,class (:foreground ,foreground ))))
-   `(guide-key/highlight-command-face ((,class (:foreground ,yellow ))))
-   `(guide-key/prefix-command-face ((,class (:foreground ,aqua ))))
+   `(guide-key/highlight-command-face ((,class (:foreground ,orange ))))
+   `(guide-key/prefix-command-face ((,class (:foreground ,blue ))))
 
    ;; which-key
    `(which-key-key-face ((,class (:foreground ,foreground  :weight bold))))

--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -388,7 +388,7 @@
 
    ;; Helm
    `(helm-header ((,class (:foreground ,foreground :background ,background))))
-   `(helm-selection ((,class (:background ,current-line))))
+   `(helm-selection ((,class (:background ,current-line :foreground ,blue))))
    `(helm-ff-file ((,class (:foreground ,foreground ))))
    `(helm-ff-directory ((,class (:foreground ,blue ))))
    `(helm-ff-executable ((,class (:foreground ,green ))))


### PR DESCRIPTION
The material light theme used yellow foreground on white background in a couple of places, what made the text very hard to read (e.g., `helm-match`, `helm-selection`, unread messages in mu4e headers). 

These patches replace the yellow foreground with colors that are more readble.

It also enables colors for flycheck fringe symbols.