### PR TITLE
Better readability of backticks in shell scripts (light theme)

### DIFF
--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -650,6 +650,7 @@
    `(mu4e-header-highlight-face ((,class (:background ,current-line :underline nil :inherit region))))
    `(mu4e-header-marks-face ((,class (:underline nil :foreground ,yellow))))
    `(mu4e-flagged-face ((,class (:foreground ,orange :inherit nil))))
+   `(mu4e-forwarded-face ((,class (:foreground ,aqua :inherit nil))))
    `(mu4e-replied-face ((,class (:foreground ,green :inherit nil))))
    `(mu4e-unread-face ((,class (:foreground ,foreground :inherit nil))))
    `(mu4e-cited-1-face ((,class (:inherit outline-1 :slant normal))))

--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -77,7 +77,7 @@
    `(font-lock-function-name-face ((,class (:foreground ,"#0097A7"))))
    `(font-lock-keyword-face ((,class (:foreground ,aqua))))
    `(font-lock-negation-char-face ((,class (:foreground ,blue))))
-   `(font-lock-preprocessor-face ((,class (:foreground "gold"))))
+   `(font-lock-preprocessor-face ((,class (:foreground ,"#0097A7"))))
    `(font-lock-regexp-grouping-backslash ((,class (:foreground ,yellow))))
    `(font-lock-regexp-grouping-construct ((,class (:foreground ,purple))))
    `(font-lock-string-face ((,class (:foreground "#689f38"))))


### PR DESCRIPTION
Another minor change to improve the readability of the light theme. Changes the color of backticks in shell scripts from gold (on white) to dark cyan (on white).

There are a few more instances of yellow on white faces. Do you have any suggestions to deal with them in a systematic way?