### PR TITLE
Set background color for company template

### DIFF
--- a/material-theme.el
+++ b/material-theme.el
@@ -592,7 +592,7 @@
    ;; `(company-preview-search ((,class ())))
    `(company-scrollbar-bg ((,class (:background "#F0F0F0"))))
    `(company-scrollbar-fg ((,class (:background "#C0C0C0"))))
-   ;; `(company-template-field ((,class ())))
+   `(company-template-field ((,class (:background ,inactive-gray))))
    `(company-tooltip ((,class (:weight bold :foreground, far-background :background ,inactive-gray))))
    `(company-tooltip-annotation ((,class (:weight normal :foreground ,comment :background ,inactive-gray))))
    `(company-tooltip-common ((,class (:weight normal :inherit company-tooltip))))


### PR DESCRIPTION
Noticed that the template background for company-mode is not set.

Not completely sure if this is the correct color to use though.

Before:
<img width="280" alt="screen shot 2016-01-18 at 09 21 50" src="https://cloud.githubusercontent.com/assets/174496/12386315/fa89765a-bdc4-11e5-8a0d-c8ec52d3ddd0.png">

After:
<img width="285" alt="screen shot 2016-01-18 at 09 20 38" src="https://cloud.githubusercontent.com/assets/174496/12386320/ff81f3b2-bdc4-11e5-8a27-b5d163726dae.png">
