### PR TITLE
Added colors for erc-colorize

### DIFF
--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -796,6 +796,15 @@
    `(erc-timestamp-face ((,class (:foreground ,aqua))))
    `(erc-keyword-face ((,class (:foreground ,green))))
 
+   ;; erc-colorize
+   `(erc-distinct-1-face ((,class (:foreground ,"#E91E63"))))
+   `(erc-distinct-2-face ((,class (:foreground ,"#1565C0"))))
+   `(erc-distinct-3-face ((,class (:foreground ,"#827717"))))
+   `(erc-distinct-4-face ((,class (:foreground ,"#B388FF"))))
+   `(erc-distinct-5-face ((,class (:foreground ,"#EF6C00"))))
+   `(erc-distinct-6-face ((,class (:foreground ,"#26A69A"))))
+   `(erc-distinct-7-face ((,class (:foreground ,"#B71C1C"))))
+
    ;; twittering-mode
    `(twittering-username-face ((,class (:inherit erc-pal-face))))
    `(twittering-uri-face ((,class (:foreground ,blue :inherit link))))

--- a/material-theme.el
+++ b/material-theme.el
@@ -790,6 +790,15 @@
    `(erc-timestamp-face ((,class (:foreground ,aqua))))
    `(erc-keyword-face ((,class (:foreground ,green))))
 
+   ;; erc-colorize
+   `(erc-distinct-1-face ((,class (:foreground ,"#E91E63"))))
+   `(erc-distinct-2-face ((,class (:foreground ,"#2196F3"))))
+   `(erc-distinct-3-face ((,class (:foreground ,"#DCE775"))))
+   `(erc-distinct-4-face ((,class (:foreground ,"#B388FF"))))
+   `(erc-distinct-5-face ((,class (:foreground ,"#EF6C00"))))
+   `(erc-distinct-6-face ((,class (:foreground ,"#26A69A"))))
+   `(erc-distinct-7-face ((,class (:foreground ,"#FFCDD2"))))
+
    ;; twittering-mode
    `(twittering-username-face ((,class (:inherit erc-pal-face))))
    `(twittering-uri-face ((,class (:foreground ,blue :inherit link))))


### PR DESCRIPTION
`erc-colorize` is a mode that assign a color to each user in an IRC chat room with a unique color, so text written by user a is in red and text written by user b is blue, etc, making it easy to follow a conversation in an ERC buffer.

I reused some of the colors defined by the rainbow-delimiters. They look really nice on the dark version, and should look good on the light version.

I do realize that erc-colorize is a niche mode, but the default blue color blends really horribly with the background color of Material.