### PR TITLE
Fix broken search highlights

### DIFF
--- a/material-light-theme.el
+++ b/material-light-theme.el
@@ -180,8 +180,7 @@
    ;; Search
    `(match ((,class (:foreground ,background :background ,green :inverse-video nil))))
    `(isearch ((,class (:foreground ,background :background ,green))))
-   `(isearch-lazy-highlight-face ((,class (:foreground ,background :background ,green :inverse-video nil))))
-   `(lazy-highlight-face ((,class (:foreground ,background :background ,green :inverse-video nil))))
+   `(lazy-highlight ((,class (:foreground ,background :background ,green :inverse-video nil))))
    `(isearch-fail ((,class (:background ,background :inherit font-lock-warning-face :inverse-video t))))
 
    ;; Evil
@@ -196,7 +195,7 @@
 
    ;; Anzu
    `(anzu-mode-line ((,class (:foreground ,orange))))
-   `(anzu-replace-highlight ((,class (:inherit isearch-lazy-highlight-face))))
+   `(anzu-replace-highlight ((,class (:inherit lazy-highlight))))
    `(anzu-replace-to ((,class (:inherit isearch))))
 
    ;; IDO

--- a/material-theme.el
+++ b/material-theme.el
@@ -177,8 +177,7 @@
    ;; Search
    `(match ((,class (:foreground ,background :background ,green :inverse-video nil))))
    `(isearch ((,class (:foreground ,foreground :background ,green))))
-   `(isearch-lazy-highlight-face ((,class (:foreground ,background :background ,green :inverse-video nil))))
-   `(lazy-highlight-face ((,class (:foreground ,background :background ,green :inverse-video nil))))
+   `(lazy-highlight ((,class (:foreground ,background :background ,green :inverse-video nil))))
    `(isearch-fail ((,class (:background ,background :inherit font-lock-warning-face :inverse-video t))))
 
    ;; Evil
@@ -193,7 +192,7 @@
 
    ;; Anzu
    `(anzu-mode-line ((,class (:foreground ,orange))))
-   `(anzu-replace-highlight ((,class (:inherit isearch-lazy-highlight-face))))
+   `(anzu-replace-highlight ((,class (:inherit lazy-highlight))))
    `(anzu-replace-to ((,class (:inherit isearch))))
 
    ;; IDO


### PR DESCRIPTION
`isearch-lazy-hightlight-face' was declared obsolete in Emacs 22.1 and was
removed from Emacs 25.1 in favor of `lazy-hightlight'. Thus, search highlighting
had no effect. This fixes the issue.